### PR TITLE
Fixing typo in lint.js

### DIFF
--- a/gulp-tasks/lint.js
+++ b/gulp-tasks/lint.js
@@ -13,7 +13,7 @@ module.exports = {
   // Lint Sass based on .stylelintrc.yml config.
   lintSass: function () {
     return src([
-      './src/patterns/{03-layouts,05-components}/**/*.scss',
+      './src/patterns/{03-layouts,04-components}/**/*.scss',
       './src/styleguide/*.scss',
     ])
       .pipe(


### PR DESCRIPTION
There was a type in the lint.js so that the components never got linted, it was say 05-components, now fixed to 04-components.